### PR TITLE
Add number of iterations and decimal places for slowerBy

### DIFF
--- a/benchmarkers.js
+++ b/benchmarkers.js
@@ -1,7 +1,15 @@
 const { runner, runnerPromise } = require('./runner');
 
 let accumulator = [];
-const iterations = Date.now() % 1000;
+let iterations = Date.now() % 1000;
+
+function setIterations(numIterations){
+  iterations = numIterations;
+}
+
+function getIterations(){
+  return iterations;
+}
 
 function captureArgs(args) {
   const _args = [];
@@ -27,6 +35,8 @@ async function benchmarkPromise(func) {
 }
 
 module.exports = {
+  getIterations,
+  setIterations,
   benchmark,
   accumulator,
   iterations,

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const getSum = (timeBenchData) => {
   return timeBenchData.ending - timeBenchData.init;
 };
 
-const show = () => {
+const show = ({slowerByDecimalPlaces} = {slowerByDecimalPlaces: 0}) => {
   const results = calculate();
   const represent = Object.keys(results)
     .map(key => ({
@@ -36,7 +36,7 @@ const show = () => {
       ns: results[key].average,
       ms: results[key].average / 1e6
     }));
-  determineInference(represent);
+  determineInference(represent, slowerByDecimalPlaces);
   const options = {
      leftPad: 2,
     columns: [

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 const chalk = require('chalk');
 const chalkTable = require('chalk-table');
 const { determineInference } = require('./inference');
-const { benchmark, benchmarkPromise, accumulator, iterations } = require('./benchmarkers');
+const { benchmark, benchmarkPromise, accumulator, getIterations, setIterations } = require('./benchmarkers');
 
 const calculate = () => {
+  const iterations = getIterations();
   const functions = new Set(accumulator.map(el => el.name));
   const functionTotalTime = {};
   for (let name of functions) {
@@ -45,11 +46,13 @@ const show = () => {
       { field: 'slowerBy', name: chalk.red('Slower by') },
     ]
   };
-  console.log(`${chalk.cyan('Iterations')}: ${iterations}`);
+  console.log(`${chalk.cyan('Iterations')}: ${getIterations()}`);
   console.log(chalkTable(options, represent));
 };
 
 module.exports = {
+  getIterations,
+  setIterations,
   benchmark,
   benchmarkPromise,
   show,

--- a/inference.js
+++ b/inference.js
@@ -2,13 +2,13 @@ const sorter = (first, second) => {
   return first.ns - second.ns;
 };
 
-const determineInference = results => {
+const determineInference = (results, slowerByDecimalPlaces=0) => {
   results.sort(sorter);
   const [ fastest ] = results;
   fastest.slowerBy = 'fastest';
   if (typeof fastest !== undefined) {
     for (var index = 1; index < results.length; ++index) {
-      results[index].slowerBy = `${parseInt(results[index].ns / fastest.ns, 10)}x`;
+      results[index].slowerBy = `${parseFloat(results[index].ns / fastest.ns, 10).toFixed(slowerByDecimalPlaces)}x`;
     }
   }
 };


### PR DESCRIPTION
Two very simple changes.

Add `get/setIterations` allowing for manually setting the number of iterations, the default is not sufficient for small and fast functions as is depends on current time.

Allow specifying decimal places for slowerBy column, by passing `slowerByDecimalPlaces`.